### PR TITLE
Fixing the `eo` extension shortcode and use the schema URL instead

### DIFF
--- a/examples/example-tiled-assets-dimension.json
+++ b/examples/example-tiled-assets-dimension.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
     "https://stac-extensions.github.io/tiled-assets/v1.0.0/schema.json",
-    "eo"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "id": "sen2l2a-cog-converted",
   "type": "Feature",

--- a/examples/example-tiled-assets-tiled.json
+++ b/examples/example-tiled-assets-tiled.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0-rc.1",
   "stac_extensions": [
     "https://stac-extensions.github.io/tiled-assets/v1.0.0/schema.json",
-    "eo"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "id": "s2cloudless_2018",
   "type": "Feature",


### PR DESCRIPTION

Fixes #4

**Related Issue(s):** #

#4

**Proposed Changes:**

1. use full eo extension URL instead

**PR Checklist:**

- [ ] This PR is made against the `dev` branch (all proposed changes except releases should be against `dev`, not main).
- [x] This PR has **no** breaking changes.
- [x] I have added my changes to the CHANGELOG **or** a CHANGELOG entry is not required.
